### PR TITLE
Including Arduino.h header in AP_Filter/MovingAverageFilter.cpp, and updating iCompass.h::iround() method

### DIFF
--- a/libraries/AP_Filter/MovingAvarageFilter.cpp
+++ b/libraries/AP_Filter/MovingAvarageFilter.cpp
@@ -2,6 +2,7 @@
 https://github.com/sebnil/Moving-Avarage-Filter--Arduino-Library-
 */
 #include <stdlib.h>
+#include "Arduino.h"
 #include "MovingAvarageFilter.h"
 
 MovingAvarageFilter::MovingAvarageFilter(unsigned int newDataPointsCount) {

--- a/libraries/iCompass/iCompass.h
+++ b/libraries/iCompass/iCompass.h
@@ -57,9 +57,10 @@ class iCompass
 
     //=======================================
     float iround(float number, float decimal) {
-      int ix;
-      ix = round(number*pow(10, decimal));
-      return float(ix)/pow(10, decimal);
+      //int ix;
+      //ix = round(number*pow(10, decimal));
+      // return float(ix)/pow(10, decimal);
+      return float(round(number*pow(10, decimal)))/pow(10, decimal);
     }
 
     //=======================================


### PR DESCRIPTION
Checke out from master, noticed I couldn't compile my sketch. I was missing an include statement for the Arduino.h header in MovingAverageFilter.cpp

Also noticed we could save a few more bytes by inlining the `int ix;` variable in `libraries/iCompass/iCompass.h::iround()`

