### PR TITLE
Adafruit 10DOF : L3G not fully initialized

### DIFF
--- a/libraries/FreeIMU/FreeIMU.cpp
+++ b/libraries/FreeIMU/FreeIMU.cpp
@@ -1036,16 +1036,12 @@ void FreeIMU::RESET_Q() {
   //ALTIMU or Adafruit 10-DOF SENSOR INIT
   #if HAS_L3D20()
     gyro.init();
-    //gyro.enableDefault();
+    gyro.enableDefault();
     //					Sensitivity
     //+/-245:        0x00	8.75	
     //+/-500:        0x10	17.5
     //+/- 2000:      0x20	70
     gyro.writeReg(0x23, 0x20);
-    
-    // 0x6F = 0b01101111
-    // DR = 01 (200 Hz ODR); BW = 10 (50 Hz bandwidth); PD = 1 (normal mode); Zen = Yen = Xen = 1 (all axes enabled)
-    gyro.writeReg(0x20, 0x6F
     gyro_sensitivity = 70.0f;
   #endif
   

--- a/libraries/FreeIMU/FreeIMU.cpp
+++ b/libraries/FreeIMU/FreeIMU.cpp
@@ -1042,6 +1042,10 @@ void FreeIMU::RESET_Q() {
     //+/-500:        0x10	17.5
     //+/- 2000:      0x20	70
     gyro.writeReg(0x23, 0x20);
+    
+    // 0x6F = 0b01101111
+    // DR = 01 (200 Hz ODR); BW = 10 (50 Hz bandwidth); PD = 1 (normal mode); Zen = Yen = Xen = 1 (all axes enabled)
+    gyro.writeReg(0x20, 0x6F
     gyro_sensitivity = 70.0f;
   #endif
   


### PR DESCRIPTION
Hi

I noticed my L3G always send 0 for all its axes. 

However, if I load an example sketch from Adafruit's L3G library, then load again FreeIMU, I can get L3G's axes.

I lose again sensor's data if I unplug and replug my device.

Despite the axes should be enabled by default (https://cdn-shop.adafruit.com/datasheets/L3GD20H.pdf page 36) I need to explicitly enable them.
